### PR TITLE
Copper Circlet w/ Power Armor, Enchanted Rings Not Conflict, Finger Firelighter Dimming

### DIFF
--- a/Magical Nights/items/alchemy_items.json
+++ b/Magical Nights/items/alchemy_items.json
@@ -66,7 +66,7 @@
     "encumbrance": 1,
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "ONLY_ONE", "COMPACT" ],
+    "flags": [ "SKINTIGHT", "ONLY_ONE", "COMPACT", "POWERARMOR_COMPATIBLE" ],
     "qualities": [ [ "MANA_FOCUS", 1 ] ]
   },
   {

--- a/Magical Nights/items/enchanted_rings.json
+++ b/Magical Nights/items/enchanted_rings.json
@@ -13,7 +13,7 @@
     "covers": [ "hand_either" ],
     "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE", "COMPACT" ]
   },
   {
     "abstract": "mring_silver",
@@ -29,7 +29,7 @@
     "covers": [ "hand_either" ],
     "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE", "COMPACT" ]
   },
   {
     "abstract": "mring_gold",
@@ -45,7 +45,7 @@
     "covers": [ "hand_either" ],
     "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE", "COMPACT" ]
   },
   {
     "abstract": "mring_platinum",
@@ -61,7 +61,7 @@
     "covers": [ "hand_either" ],
     "coverage": 0,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE" ]
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT", "POWERARMOR_COMPATIBLE", "COMPACT" ]
   },
   {
     "copy-from": "mring_silver",

--- a/Magical Nights/items/ethereal_items.json
+++ b/Magical Nights/items/ethereal_items.json
@@ -59,7 +59,7 @@
         "target": "finger_firelighter"
       } 
   ],
-    "flags": [ "TRADER_AVOID", "FIRESTARTER", "LIGHT_8", "FLAMING", "WATER_EXTINGUISH" ]
+    "flags": [ "TRADER_AVOID", "FIRESTARTER", "FLAMING", "WATER_EXTINGUISH" ]
   },
   {
     "id": "magic_lamp",

--- a/Magical Nights/items/ethereal_items.json
+++ b/Magical Nights/items/ethereal_items.json
@@ -27,7 +27,38 @@
     "price": 0,
     "symbol": ",",
     "color": "yellow",
-    "use_action": [ { "type": "firestarter", "moves": 20 } ],
+    "use_action": [ 
+      { 
+        "type": "firestarter", "moves": 20 
+      },
+      {
+        "type": "transform",
+        "msg": "You dim the flame.",
+        "target": "finger_firelighter_off"
+      } 
+  ],
+    "flags": [ "TRADER_AVOID", "FIRESTARTER", "LIGHT_8", "FLAMING", "WATER_EXTINGUISH" ]
+  },
+  {
+    "id": "finger_firelighter_off",
+    "type": "TOOL",
+    "name": "finger firelighter (dimmed)",
+    "description": "This is a small flame you can hold in your hand.  With a thought, you can cause it to light something on fire, though it is currently dimmed.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "price": 0,
+    "symbol": ",",
+    "color": "yellow",
+    "use_action": [ 
+      { 
+        "type": "firestarter", "moves": 20 
+      },
+      {
+        "type": "transform",
+        "msg": "You brighten the flame.",
+        "target": "finger_firelighter"
+      } 
+  ],
     "flags": [ "TRADER_AVOID", "FIRESTARTER", "LIGHT_8", "FLAMING", "WATER_EXTINGUISH" ]
   },
   {
@@ -55,7 +86,7 @@
     "id": "magic_lamp_off",
     "type": "ARMOR",
     "category": "tools",
-    "name": "magic lamp",
+    "name": "magic lamp (dimmed)",
     "description": "a magical aura that you know can be brightened into a powerful light.",
     "weight": "1 g",
     "volume": "250 ml",

--- a/Magical Nights/items/ethereal_items.json
+++ b/Magical Nights/items/ethereal_items.json
@@ -41,14 +41,10 @@
   },
   {
     "id": "finger_firelighter_off",
+    "copy-from": "finger_firelighter",
     "type": "TOOL",
     "name": "finger firelighter (dimmed)",
     "description": "This is a small flame you can hold in your hand.  With a thought, you can cause it to light something on fire, though it is currently dimmed.",
-    "weight": "1 g",
-    "volume": "1 ml",
-    "price": 0,
-    "symbol": ",",
-    "color": "yellow",
     "use_action": [ 
       { 
         "type": "firestarter", "moves": 20 


### PR DESCRIPTION
Makes copper circlet compatible with power armor, made enchanted rings have the COMPACT flag, made the finger firelighter able to transform into a non-lit-up version.